### PR TITLE
Fix tutorial exports

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -2,3 +2,4 @@
 - Renamed src/engine/utils to utils.js and updated imports
 - Added schema validation for loading and saving game state
 - Added devSuite folder with Node, Vite, Zod, and Jest tooling
+- Fixed tutorial imports and restored drawTutorialQuestion

--- a/src/constants/tutorialSteps.js
+++ b/src/constants/tutorialSteps.js
@@ -1,4 +1,5 @@
 import { SCREENS }   from '../constants/screens.js';
+import { State }     from '../state.js';
 
 /** Advance tutorial step (call after a reveal accept if you like) */
 export function advanceStep() {

--- a/src/engine/tutorialEngine.js
+++ b/src/engine/tutorialEngine.js
@@ -76,3 +76,37 @@ export function startTutorial() {
 export function endTutorial() {
   _end();
 }
+
+export { advanceStep } from '../constants/tutorialSteps.js';
+
+// ------------------------------------------------------------------
+// Legacy tutorial question logic (Tier 0 cards)
+
+const TUTORIAL_IDS = ['TUT001', 'TUT002'];
+
+export function drawTutorialQuestion(state) {
+  const deck     = state.questionDeck || [];
+  const answered = state.answeredQuestionIds || new Set();
+  const step     = state.tutorial?.step ?? 0;
+
+  const tutPool = deck.filter(
+    q => q.tier === 0 && TUTORIAL_IDS.includes(String(q.id))
+  );
+  if (!tutPool.length) return { question: null, answers: [], category: '' };
+
+  const preferredId = TUTORIAL_IDS[Math.min(step, TUTORIAL_IDS.length - 1)];
+  let q =
+    tutPool.find(q => String(q.id) === preferredId && !answered.has(q.id)) ||
+    tutPool.find(q => !answered.has(q.id)) ||
+    tutPool[0];
+
+  const keys = ['A', 'B', 'C'];
+  const answers = (q.answers || []).slice(0, 3).map((a, i) => ({
+    key:         keys[i],
+    label:       a.label,
+    answerClass: a.answerClass,
+    explanation: a.explanation,
+  }));
+
+  return { question: q, answers, category: q.category || q.title || '' };
+}


### PR DESCRIPTION
## Summary
- wire up missing import to tutorial steps
- re-export advanceStep from tutorial engine and restore drawTutorialQuestion
- note the patch in `logs/improvements.md`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cce70c0148332b62ac206903a881c