### PR TITLE
Centralize Grin flavor text (GRIN_PHASES + grinEngine) and wire Waiting Room observed line

### DIFF
--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -5,3 +5,4 @@
 - Fixed tutorial imports and restored drawTutorialQuestion
 - Enabled tier escalation and deck refresh with memory-based answer blocking
 - Added reset-game action to replay from Final Reading
+- Added a centralized Grin flavor text system and migrated the Waiting Room observed-count line to it.

--- a/src/constants/flavorText.js
+++ b/src/constants/flavorText.js
@@ -1,0 +1,47 @@
+// src/constants/flavorText.js
+// Centralized voice lines for Nous. Engines select and interpolate; UI only displays.
+
+export const GRIN_PHASES = {
+  WHISPER: 'WHISPER',
+  GRIN: 'GRIN',
+  SHATTER: 'SHATTER',
+};
+
+export const FLAVOR_TEXT = {
+  WAITING_ROOM_OBSERVED: {
+    [GRIN_PHASES.WHISPER]: [
+      'Nous hears {gathered} gathered. It observes {observed}.',
+      '{gathered} gathered. {observed} observed. Nous does not miscount.',
+      'You count {gathered}. Nous counts {observed}. Begin anyway.',
+    ],
+    [GRIN_PHASES.GRIN]: [
+      'You brought {gathered}. Nous brought the number to {observed}.',
+      '{gathered} voices at the table. {observed} shadows listening.',
+    ],
+    [GRIN_PHASES.SHATTER]: [
+      '{gathered} gathered. {observed} observed. One of those numbers is inside you.',
+    ],
+  },
+
+  // Existing trait intrusion lines, staged here for future migration.
+  TRAIT_INTRUSION_MEASURING_DOORFRAME: {
+    [GRIN_PHASES.WHISPER]: [
+      'You’re measuring the doorframe again. You will fit.',
+    ],
+  },
+  TRAIT_INTRUSION_NEVER_ANSWER_ASKED: {
+    [GRIN_PHASES.WHISPER]: [
+      'You never answer the question asked. That’s why you’re interesting.',
+    ],
+  },
+  TRAIT_INTRUSION_PLAN_SIDEWAYS: {
+    [GRIN_PHASES.WHISPER]: [
+      'One of you keeps tugging the plan sideways. They’re usually right… at first.',
+    ],
+  },
+  TRAIT_INTRUSION_STOP_PERFORMING: {
+    [GRIN_PHASES.WHISPER]: [
+      'Stop performing for each other. I already know.',
+    ],
+  },
+};

--- a/src/engine/grinEngine.js
+++ b/src/engine/grinEngine.js
@@ -1,0 +1,56 @@
+// src/engine/grinEngine.js
+import { State } from '../state.js';
+import { FLAVOR_TEXT, GRIN_PHASES } from '../constants/flavorText.js';
+
+const PHASE_ORDER = [GRIN_PHASES.WHISPER, GRIN_PHASES.GRIN, GRIN_PHASES.SHATTER];
+
+function stableHash(value) {
+  const str = typeof value === 'string' ? value : JSON.stringify(value ?? '');
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i += 1) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function interpolate(line, context = {}) {
+  return String(line ?? '').replace(/\{([A-Za-z0-9_]+)\}/g, (match, token) => {
+    if (Object.prototype.hasOwnProperty.call(context, token)) {
+      return String(context[token]);
+    }
+    return match;
+  });
+}
+
+export function getGrinPhase(state = State.getState()) {
+  const explicit = state?.grinPhase;
+  if (PHASE_ORDER.includes(explicit)) return explicit;
+
+  const roundsWon = Number(state?.roundsWon || 0);
+  const roundNumber = Number(state?.roundNumber || 1);
+  const traitMagnitude = Object.values(state?.traits || {})
+    .reduce((sum, value) => sum + Math.abs(Number(value) || 0), 0);
+
+  if (roundsWon >= 2 || roundNumber >= 3 || traitMagnitude >= 15) return GRIN_PHASES.SHATTER;
+  if (roundsWon >= 1 || roundNumber >= 2 || traitMagnitude >= 8) return GRIN_PHASES.GRIN;
+  return GRIN_PHASES.WHISPER;
+}
+
+export function getGrinLine(key, context = {}, options = {}) {
+  const state = options.state || State.getState();
+  const phase = options.phase || getGrinPhase(state);
+  const entry = FLAVOR_TEXT[key];
+  if (!entry) return '';
+
+  const variants = entry[phase] || entry[GRIN_PHASES.WHISPER] || [];
+  const lines = Array.isArray(variants) ? variants : [variants];
+  if (!lines.length) return '';
+
+  const seed = options.seed ?? { key, phase, context };
+  const index = Number.isInteger(options.variantIndex)
+    ? options.variantIndex
+    : stableHash(seed) % lines.length;
+
+  return interpolate(lines[((index % lines.length) + lines.length) % lines.length], context);
+}

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -8,6 +8,7 @@ import * as Q       from './engine/questionEngine.js';
 import * as Fate    from './engine/fateEngine.js';
 import * as Round   from './engine/roundEngine.js';
 import * as Tutor   from './engine/tutorialEngine.js';
+import { getGrinLine } from './engine/grinEngine.js';
 
 /* ---------------- helpers ---------------- */
 
@@ -158,10 +159,16 @@ const ACTIONS = {
   'participants-down': () => (UI.adjustParticipantCount(-1), {}),
   'participants-up'  : () => (UI.adjustParticipantCount(+1), {}),
   'participants-confirm': () => {
-    const n = UI.confirmParticipants();   // shows the eerie line (impure in current UI)
+    const gathered = UI.confirmParticipants();
+    const observed = gathered + 1;
+    const line = getGrinLine('WAITING_ROOM_OBSERVED', { gathered, observed });
+
+    State.patch({ gatheredCount: gathered, observedCount: observed });
+    UI.showParticipantFlavor(line);
 
     setTimeout(() => {
-      State.initializeGame(n);
+      State.initializeGame(gathered);
+      State.patch({ gatheredCount: gathered, observedCount: observed });
       applyResult({ next: SCREENS.GAME_LOBBY });
     }, 900);
 

--- a/src/state.js
+++ b/src/state.js
@@ -26,6 +26,9 @@ function buildInitialState() {
     roundsToWin: DEFAULTS.roundsToWin,
     roundsWon: 0,
     roundNumber: 1,
+    gatheredCount: 0,
+    observedCount: 0,
+    grinPhase: null,
 
     /* ---- Round runtime ---- */
     roundScore: 0,
@@ -160,6 +163,9 @@ function initializeGame(participants = 1) {
     roundsToWin: DEFAULTS.roundsToWin,
     roundsWon: 0,
     roundNumber: 1,
+    gatheredCount: Math.max(1, Number(participants) || 1),
+    observedCount: Math.max(1, Number(participants) || 1) + 1,
+    grinPhase: null,
 
     // Round runtime
     roundScore: 0,

--- a/src/ui.js
+++ b/src/ui.js
@@ -187,11 +187,10 @@ export const UI = (() => {
   const confirmParticipants = () => pCount;
 
   // Called by handleAction AFTER confirmParticipants()
-  const showParticipantFlavor = (n) => {
+  const showParticipantFlavor = (text) => {
     if (!flavor) return;
-    const noun = n === 1 ? 'voice' : 'voices';
-    flavor.textContent = `Nous hears ${n} ${noun}. It prefers odd numbers.`;
-    flavor.hidden = false;
+    flavor.textContent = String(text ?? '');
+    flavor.hidden = !flavor.textContent;
   };
 
   const showParticipantEntry = () => {


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for the game’s voice/flavor lines so future migrations can use consistent keys and deterministic variants.
- Allow engines to pick phase-appropriate lines (WHISPER / GRIN / SHATTER) and interpolate tokens without refactoring the whole game.
- Replace ad-hoc Waiting Room text with a call into the centralized system so flavor can evolve independently from UI code.

### Description
- Added `src/constants/flavorText.js` exporting `GRIN_PHASES` and `FLAVOR_TEXT` with `WAITING_ROOM_OBSERVED` variants and staged trait intrusion keys for later migration.
- Added `src/engine/grinEngine.js` exporting `getGrinPhase(state)` and `getGrinLine(key, context, options)` with deterministic variant selection, WHISPER fallback, and `{token}` interpolation.
- Updated `src/handleAction.js` Waiting Room confirmation to: read `gathered` via `UI.confirmParticipants()`, compute `observed = gathered + 1`, call `getGrinLine('WAITING_ROOM_OBSERVED', { gathered, observed })`, store `gatheredCount`/`observedCount` in state, display the returned text, and then continue to the Game Lobby after the short flavor delay.
- Added `gatheredCount`, `observedCount`, and `grinPhase` to initial and `initializeGame()` state so the values persist through initialization, and changed `UI.showParticipantFlavor()` to accept already-resolved text (UI remains display-only).
- Logged the change in `logs/improvements.md` so the tweak is discoverable for future work.

### Testing
- Ran a small node check that calls `getGrinLine('WAITING_ROOM_OBSERVED', { gathered: 2, observed: 3 }, { phase: 'WHISPER' })` and confirmed the returned string includes both `2` and `3`; this check passed.
- Ran `npm run build` (Vite production build) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0678fb738c83258cecb9ec802765fc)