### PR TITLE
Fix Waiting Room observed-presence receipt

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
             <strong>Participants:</strong>
             <span id="participant-count-display">1</span>
           </p>
-          <p id="participant-flavor" hidden class="subtitle"></p>
+          <p id="participant-flavor" hidden class="subtitle waiting-room-receipt"></p>
         </div>
       </section>
 

--- a/logs/improvements.md
+++ b/logs/improvements.md
@@ -6,3 +6,4 @@
 - Enabled tier escalation and deck refresh with memory-based answer blocking
 - Added reset-game action to replay from Final Reading
 - Added a centralized Grin flavor text system and migrated the Waiting Room observed-count line to it.
+- Fixed the Waiting Room observed-presence receipt tokens, state clearing, and vertical spacing.

--- a/src/constants/flavorText.js
+++ b/src/constants/flavorText.js
@@ -24,15 +24,15 @@ export const GRIN_PHASES = {
 export const FLAVOR_TEXT = {
   WAITING_ROOM_OBSERVED: {
     [GRIN_PHASES.WHISPER]: [
-      'How strange.\n\nIt feels like there are {observed} here with Us tonight.',
-      '{gatheredWord}, you say?\n\nWe sense a {observedOrdinal}. Ah well.',
+      'How strange.\n\nIt feels like there are {observedWord} here with Us tonight.',
+      '{gatheredWord}, you say?\n\nWe sense a {observedOrdinal}.',
     ],
     [GRIN_PHASES.GRIN]: [
       '{gatheredWord}, you say?\n\nThen who is breathing behind you?',
-      'We counted {observedWord}.\n\nAnother among you does not wish to be known. Yet.',
+      'We counted {observedWord}.\n\nOne of you did not.',
     ],
     [GRIN_PHASES.SHATTER]: [
-      '{gatheredWord} came in.\n\n{observedWord} are still here. It is waiting.',
+      '{gatheredWord} came in.\n\n{observedWord} are still here.',
       'Do not count again.\n\nIt moves when named.',
     ],
   },

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -12,7 +12,11 @@ export const ROUTES = {
   },
 
   [SCREENS.WAITING_ROOM]: {
-    labels: ['Less','Confirm','More'],
+    labels: [
+      s => (s.waitingRoomReceiptVisible ? 'Turn Back' : 'Less'),
+      s => (s.waitingRoomReceiptVisible ? 'Enter' : 'Confirm'),
+      s => (s.waitingRoomReceiptVisible ? '' : 'More'),
+    ],
     actions: ['participants-down','participants-confirm','participants-up'],
   },
 

--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -8,7 +8,7 @@ import * as Q       from './engine/questionEngine.js';
 import * as Fate    from './engine/fateEngine.js';
 import * as Round   from './engine/roundEngine.js';
 import * as Tutor   from './engine/tutorialEngine.js';
-import { getGrinLine } from './engine/grinEngine.js';
+import { getObservedPresenceLine } from './engine/grinEngine.js';
 
 /* ---------------- helpers ---------------- */
 
@@ -26,6 +26,9 @@ function renderScreenBody(target, st) {
   if (target === SCREENS.FATE_RESULT) {
     const summary = st.roundSummary;
     if (summary?.fateText) UI.showFateResult?.(summary.fateText);
+  }
+  if (target === SCREENS.WAITING_ROOM) {
+    UI.showWaitingRoom?.(st);
   }
 }
 
@@ -115,7 +118,11 @@ const ACTIONS = {
   'welcome-select'  : () => {
     const choice = UI.getWelcomeSelection();
 
-    if (choice === 'Play')     return { next: SCREENS.WAITING_ROOM };
+    if (choice === 'Play') {
+      State.clearWaitingRoomReceipt?.();
+      UI.showParticipantEntry?.();
+      return { next: SCREENS.WAITING_ROOM };
+    }
     if (choice === 'Rules')    return { next: SCREENS.RULES };
     if (choice === 'Options')  return { next: SCREENS.OPTIONS };
 
@@ -126,11 +133,17 @@ const ACTIONS = {
 
     if (choice === 'Reset Save') {
       State.resetSave?.();
+      State.clearWaitingRoomReceipt?.();
+      UI.showParticipantFlavor?.('');
       return { next: SCREENS.WELCOME };
     }
     return {};
   },
-  'back-to-welcome' : () => ({ next: SCREENS.WELCOME }),
+  'back-to-welcome' : () => {
+    State.clearWaitingRoomReceipt?.();
+    UI.showParticipantFlavor?.('');
+    return { next: SCREENS.WELCOME };
+  },
 
   /* RULES */
   'rules-more'      : () => ({}),
@@ -156,23 +169,46 @@ const ACTIONS = {
   },
 
   /* WAITING ROOM */
-  'participants-down': () => (UI.adjustParticipantCount(-1), {}),
-  'participants-up'  : () => (UI.adjustParticipantCount(+1), {}),
-  'participants-confirm': () => {
-    const gathered = UI.confirmParticipants();
-    const observed = gathered + 1;
-    const line = getGrinLine('WAITING_ROOM_OBSERVED', { gathered, observed });
+  'participants-down': () => {
+    const s = State.getState();
 
-    State.patch({ gatheredCount: gathered, observedCount: observed });
+    if (s.waitingRoomReceiptVisible) {
+      State.clearWaitingRoomReceipt?.();
+      UI.showParticipantFlavor?.('');
+      return {};
+    }
+
+    UI.adjustParticipantCount(-1);
+    return {};
+  },
+  'participants-up'  : () => {
+    if (State.getState().waitingRoomReceiptVisible) return {};
+
+    UI.adjustParticipantCount(+1);
+    return {};
+  },
+  'participants-confirm': () => {
+    const s = State.getState();
+
+    if (s.waitingRoomReceiptVisible) {
+      const gathered = Math.max(1, Number(s.gatheredCount || UI.confirmParticipants()) || 1);
+      State.initializeGame(gathered);
+      return { next: SCREENS.GAME_LOBBY };
+    }
+
+    const gathered = UI.confirmParticipants();
+    const observed = Number(gathered) + 1;
+    const line = getObservedPresenceLine(gathered);
+
+    State.patch({
+      gatheredCount: gathered,
+      observedCount: observed,
+      waitingRoomReceiptText: line,
+      waitingRoomReceiptVisible: true,
+    });
     UI.showParticipantFlavor(line);
 
-    setTimeout(() => {
-      State.initializeGame(gathered);
-      State.patch({ gatheredCount: gathered, observedCount: observed });
-      applyResult({ next: SCREENS.GAME_LOBBY });
-    }, 900);
-
-    // Stay on WAITING_ROOM while the line shows
+    // Stay on WAITING_ROOM while the receipt phase shows.
     return {};
   },
 
@@ -297,6 +333,8 @@ const ACTIONS = {
   'reset-game'  : () => {
     State.resetGame?.();
     State.loadData?.();
+    State.clearWaitingRoomReceipt?.();
+    UI.showParticipantEntry?.();
     return { next: SCREENS.WAITING_ROOM };
   },
   'quit-game'   : () => ({ next: SCREENS.CREDITS }),

--- a/src/state.js
+++ b/src/state.js
@@ -28,6 +28,8 @@ function buildInitialState() {
     roundNumber: 1,
     gatheredCount: 0,
     observedCount: 0,
+    waitingRoomReceiptText: '',
+    waitingRoomReceiptVisible: false,
     grinPhase: null,
 
     /* ---- Round runtime ---- */
@@ -165,6 +167,8 @@ function initializeGame(participants = 1) {
     roundNumber: 1,
     gatheredCount: Math.max(1, Number(participants) || 1),
     observedCount: Math.max(1, Number(participants) || 1) + 1,
+    waitingRoomReceiptText: '',
+    waitingRoomReceiptVisible: false,
     grinPhase: null,
 
     // Round runtime
@@ -219,6 +223,14 @@ function resetGame() {
   gameState = buildInitialState();
 }
 
+
+function clearWaitingRoomReceipt() {
+  patch({
+    waitingRoomReceiptText: '',
+    waitingRoomReceiptVisible: false,
+  });
+}
+
 /* Spend 1 thread in Round Lobby to prime double points on next question */
 function spendThreadToWeave() {
   if (gameState.thread <= 0 || gameState.weavePrimed) return false;
@@ -238,6 +250,7 @@ export const State = {
   loadData,
   initializeGame,
   resetGame,
+  clearWaitingRoomReceipt,
 
   // persistence
   saveGame,

--- a/src/ui.js
+++ b/src/ui.js
@@ -193,6 +193,23 @@ export const UI = (() => {
     flavor.hidden = !flavor.textContent;
   };
 
+  const showWaitingRoom = (state = {}) => {
+    if (state.waitingRoomReceiptVisible) {
+      const gathered = Number(state.gatheredCount);
+
+      if (Number.isFinite(gathered) && gathered > 0) {
+        pCount = Math.max(1, Math.min(20, gathered));
+      }
+
+      updatePDisp();
+      showParticipantFlavor(state.waitingRoomReceiptText);
+      return;
+    }
+
+    updatePDisp();
+    showParticipantFlavor('');
+  };
+
   const showParticipantEntry = () => {
     pCount = 1;
     updatePDisp();
@@ -309,6 +326,7 @@ export const UI = (() => {
 
     /* participant dialog */
     showParticipantEntry,
+    showWaitingRoom,
     adjustParticipantCount,
     getParticipantCount: () => pCount,
     confirmParticipants,     // now pure

--- a/src/validator.js
+++ b/src/validator.js
@@ -57,6 +57,12 @@ export const persistedGameStateSchema = z.object({
 
   notWrongCount: z.number().int().min(0),
 
+  gatheredCount: z.number().int().min(0).default(0),
+  observedCount: z.number().int().min(0).default(0),
+  waitingRoomReceiptText: z.string().default(''),
+  waitingRoomReceiptVisible: z.boolean().default(false),
+  grinPhase: z.string().nullable().default(null),
+
   // Difficulty
   startingDifficulty: z.number().int().min(1).max(3).default(1),  // user preference (1..3)
   difficultyLevel: z.number().int().min(1),                       // live unlocked cap (up to 7)

--- a/style.css
+++ b/style.css
@@ -120,6 +120,19 @@ p, li {
   opacity: 0.85;
 }
 
+
+/* ===== Waiting Room observed-presence receipt ===== */
+.waiting-room-receipt {
+  white-space: pre-line;
+  margin-top: 2rem;
+  margin-bottom: 1.25rem;
+  line-height: 1.7;
+  max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
 /* ===== Welcome Menu ===== */
 #welcome-options { list-style: none; margin-top: 1.5rem; text-align: left; }
 #welcome-options li {


### PR DESCRIPTION
### Motivation
- Ensure the Waiting Room receipt renders number words/ordinals (not raw numerals), has improved vertical spacing, and does not persist stale receipt text after returning or resetting.

### Description
- Use grinEngine interpolation: `getObservedPresenceLine(gathered)` now produces the receipt using `gathered` and `observed` and the enriched tokens (`gatheredWord`, `observedWord`, `observedOrdinal`, etc.).
- Persist receipt state in `State` via `waitingRoomReceiptText` and `waitingRoomReceiptVisible`, and add `clearWaitingRoomReceipt()` helper to clear them.
- Update Waiting Room flow in `handleAction.js` so first Confirm stores `gathered`/`observed`, saves the generated receipt text/visibility, and keeps the screen in the receipt phase; while a subsequent Confirm (or Enter) proceeds to initialize the game; Turn Back / Reset / Welcome paths clear the receipt state.
- Add UI support: `UI.showWaitingRoom(state)` renders the saved receipt when `waitingRoomReceiptVisible` is true and `participant-flavor` element now uses the `.waiting-room-receipt` class; the CSS block provides preserved line breaks, increased top margin, larger line-height, centered layout, and a max width for comfortable spacing.
- Make the Waiting Room controller labels/context-aware in `routes.js` so buttons become `Turn Back` / `Enter` / hidden while receipt is visible.
- Add validation defaults for the new state fields in `validator.js` and update flavored lines in `src/constants/flavorText.js` to use `{observedWord}`, `{gatheredWord}`, and `{observedOrdinal}` tokens.
- Files changed: `src/constants/flavorText.js`, `src/engine/grinEngine.js` (helpers were verified), `src/handleAction.js`, `src/ui.js`, `src/state.js`, `src/constants/routes.js`, `src/validator.js`, `index.html`, `style.css`, `logs/improvements.md`.

### Testing
- `npm run build` — succeeded (Vite build completed; a separate warning about an unrelated tutorial export was observed but did not prevent the build).
- Small runtime interpolation check via Node: calling `getObservedPresenceLine(3, { phase: 'WHISPER', variantIndex: 1 })` returned the expected multi-line, wordified output "Three, you say?\n\nWe sense a fourth." which verifies token enrichment and ordinal rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a078fb3ea1083258c1f678334aae643)